### PR TITLE
feat(blog): add leap tasks post and improve blockquote rendering

### DIFF
--- a/app/blog/posts/15-leap-tasks-why-your-brain-avoids-what-matters-most.mdx
+++ b/app/blog/posts/15-leap-tasks-why-your-brain-avoids-what-matters-most.mdx
@@ -1,0 +1,48 @@
+---
+title: "Leap Tasks: Why Your Brain Avoids What Matters Most"
+publishedAt: "2026-05-09"
+summary: "Making a to-do list is easy. We can easily write down six important tasks for the day. But prioritizing them—and actually executing the most important one—is where things break down."
+---
+
+## The Priority Struggle
+Making a to-do list is easy. We can easily write down six important tasks for the day. Completing it is not a big challenge either. The real challenge is doing the tasks in the right priority. Why? Your brain might prevent you from doing the most important tasks first, especially if the task is going to change you  or your environment in any way. The brain will force you to do the less important and ordinary tasks in the list (jump tasks) first and make you procrastinate the important ones(leap task) for later. 
+
+Ok, I introduced the terms leap and jump tasks. Let me explain what are jump and leap tasks in a little more detail.
+
+## The Jumps vs. Leaps
+To understand why we struggle to prioritize, we have to look at how we measure progress. We often trick ourselves into feeling productive by making progress in small, comfortable increments. Think of a frog moving forward in small, consistent jumps. 
+
+Your brain is perfectly okay with this kind of movement. But true progress often requires leapfrogging—where one leap covers the distance of many small jumps.
+
+> The Two Types of Tasks
+> *   **Jump Tasks:** Safe, predictable actions that keep you busy. They check boxes on a list, but they leave your environment and life exactly the same.
+> *   **Leap Tasks:** Uncomfortable, disruptive actions. They create massive progress, but they fundamentally change and disrupt your environment.
+
+## The Predictability Trap
+
+Lets now understand why the brain hates leap tasks. When you consistently avoid prioritizing your highest-impact task, your mind is actually working exactly as it was designed to. The brain actively avoids Leap Tasks because progress requires change. Your brain hates change because it is expensive in terms of the energy it has to spent and it is also risky. Change forces your brain to update existing models, increase attention and makes it process more prediction errors. 
+
+Your brain creates a pattern of avoidance to protect you from change for three specific reasons:
+1. **To reduce uncertainty** — unfamiliar situations are harder to predict and potentially risky.
+2. **To preserve stability** — existing routines are energy-efficient and psychologically safe.
+3. **To avoid costly adaptation** — change forces the brain to update models, increase attention, and process more prediction errors.
+
+By avoiding the Leap Task, you stay in a safe, predictable loop. But the problem is that, the more you repeat this avoidance, the stronger those neural connections become. You become trapped in a world created by your own brain's desire for safety. 
+
+Because you are inside the trap, it is very difficult to see it. To recognise it, you have to elevate your thinking and observe your own behaviour from an outside perspective. Though this sounds simple, it is nearly impossible for ordinary humans like you and me.
+
+
+ > The Avoidance Loop
+ > - By avoiding the Leap Task, you stay in a safe, predictable loop. But, the more you repeat this avoidance, the stronger those neural connections become. You become trapped in a world created by your own brain's desire for safety
+
+## Avoidance as a Compass
+Because Leap Tasks threaten the brain's desire for a predictable environment, your brain will instinctively try to prevent you from doing them. 
+
+This gives us a powerful tool for developing our prioritization skills. You don't necessarily need a complex system to figure out your true priority. Simply look for the task you have been avoiding the longest. 
+
+You are avoiding it precisely because your brain inherently knows it is a "leap task"—or a "jump task" that will ultimately lead to one. The brain recognizes that these are the actions that will force the biggest change in your life.
+
+Use your avoidance as your compass to identify the tasks with the greatest transformative potential.
+
+ > Your Procrastination is a Radar
+ > You don't need a complex system to figure out your true priority. Simply look for the task you have been avoiding the longest. Your brain inherently knows it is the action that will force the biggest change in your life.

--- a/app/global.css
+++ b/app/global.css
@@ -302,6 +302,10 @@
 	@apply m-0;
 }
 
+.prose blockquote {
+    @apply border-l-4 border-neutral-300 dark:border-neutral-700 pl-4 my-4 italic text-neutral-600 dark:text-neutral-400;
+}
+
 /* Adjusted prose styles for better readability */
 .prose p {
 	@apply paragraph-blog;
@@ -324,7 +328,11 @@
 }
 
 .prose strong {
-	@apply font-medium;
+	@apply font-semibold;
+}
+
+.prose blockquote strong {
+	@apply font-bold not-italic text-neutral-800 dark:text-neutral-200;
 }
 
 .prose ul {


### PR DESCRIPTION
- new post 15 ("Leap Tasks: Why Your Brain Avoids What Matters Most") on jump vs. leap task psychology and using avoidance as a prioritisation compass
- add .prose blockquote style (left border, italic, muted color) so the post's > callouts render as proper blockquotes
- bump .prose strong from font-medium (500) to font-semibold (600) so **bold** reads as visibly bold throughout posts
- override .prose blockquote strong to font-bold, not-italic, full-contrast color so bold inside blockquotes stays legible against the muted italic blockquote text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published new blog post: "Leap Tasks - Why Your Brain Avoids What Matters Most," exploring the distinction between high-impact tasks and lower-impact ones, and understanding avoidance patterns.

* **Style**
  * Enhanced visual styling for blockquotes and bold text in articles for improved readability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/renjith100/blog/pull/44)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->